### PR TITLE
Add an icons class and a few icons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(CMAKE_CXX_FLAGS_DEBUG   "-Wall -g -O0 ${CMAKE_CXX_FLAGS_DEBUG}")
 set(CMAKE_PREFIX_PATH "lib/qt6")
 
 set(QT_DEFAULT_MAJOR_VERSION 6)
-find_package(Qt6 COMPONENTS Core Widgets LinguistTools REQUIRED)
+find_package(Qt6 COMPONENTS Core Widgets LinguistTools Svg REQUIRED)
 if(Qt6Core_FOUND)
     message(STATUS "Found Qt6Core Version: ${Qt6Core_VERSION}")
 endif()
@@ -83,7 +83,9 @@ include_directories(
 # Source Files
 list(APPEND SRC_FILES
     src/core/data
+    src/core/icons
     src/core/storage
+    src/core/svgiconengine
     src/editor/doceditor
     src/gui/maintoolbar
     src/gui/statusbar
@@ -107,5 +109,5 @@ set(QRC_FILES
 
 qt_add_executable(Collett ${SRC_FILES} ${QRC_FILES} ${TS_FILES})
 set_target_properties(Collett PROPERTIES OUTPUT_NAME "collett")
-target_link_libraries(Collett PRIVATE Qt::Widgets)
+target_link_libraries(Collett PRIVATE Qt::Widgets Qt::Svg)
 target_compile_definitions(Collett PUBLIC "$<$<CONFIG:DEBUG>:DEBUG>")

--- a/i18n/collett_en_US.ts
+++ b/i18n/collett_en_US.ts
@@ -4,7 +4,7 @@
 <context>
     <name>Collett::GuiMain</name>
     <message>
-        <location filename="../src/guimain.cpp" line="71"/>
+        <location filename="../src/guimain.cpp" line="72"/>
         <source>%1 %2 Version %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,32 +12,32 @@
 <context>
     <name>Collett::GuiMainToolBar</name>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="41"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="42"/>
         <source>No Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="66"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
         <source>New Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="72"/>
         <source>Open Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="72"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="75"/>
         <source>Save Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="76"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="79"/>
         <source>Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="48"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="96"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -120,12 +120,12 @@
 <context>
     <name>Collett::GuiTreeToolBar</name>
     <message>
-        <location filename="../src/gui/treetoolbar.cpp" line="38"/>
+        <location filename="../src/gui/treetoolbar.cpp" line="41"/>
         <source>Story</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/treetoolbar.cpp" line="40"/>
+        <location filename="../src/gui/treetoolbar.cpp" line="43"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/collett_nb_NO.ts
+++ b/i18n/collett_nb_NO.ts
@@ -4,7 +4,7 @@
 <context>
     <name>Collett::GuiMain</name>
     <message>
-        <location filename="../src/guimain.cpp" line="71"/>
+        <location filename="../src/guimain.cpp" line="72"/>
         <source>%1 %2 Version %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,32 +12,32 @@
 <context>
     <name>Collett::GuiMainToolBar</name>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="41"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="42"/>
         <source>No Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="66"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
         <source>New Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="72"/>
         <source>Open Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="72"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="75"/>
         <source>Save Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="76"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="79"/>
         <source>Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="48"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="96"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -120,12 +120,12 @@
 <context>
     <name>Collett::GuiTreeToolBar</name>
     <message>
-        <location filename="../src/gui/treetoolbar.cpp" line="38"/>
+        <location filename="../src/gui/treetoolbar.cpp" line="41"/>
         <source>Story</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/treetoolbar.cpp" line="40"/>
+        <location filename="../src/gui/treetoolbar.cpp" line="43"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/collett.h
+++ b/src/collett.h
@@ -26,9 +26,4 @@
 #define COL_VERSION_NUM  0x000001a0
 #define COL_VERSION_DATE "2021-11-14"
 
-#define COL_PROJECT_FILE_NAME  "project.collett"
-#define COL_SETTINGS_FILE_NAME "project.json"
-#define COL_STORY_FILE_NAME    "story.json"
-#define COL_NOTES_FILE_NAME    "notes.json"
-
 #endif // COLLETT_H

--- a/src/core/icons.cpp
+++ b/src/core/icons.cpp
@@ -1,0 +1,112 @@
+/*
+** Collett – Core Icon Repository
+** ==============================
+**
+** This file is a part of Collett
+** Copyright 2020–2021, Veronica Berglyd Olsen
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "icons.h"
+#include "svgiconengine.h"
+
+#include <QIcon>
+#include <QColor>
+#include <QDebug>
+#include <QString>
+#include <QPalette>
+#include <QApplication>
+
+namespace Collett {
+
+CollettIcons *CollettIcons::staticInstance = nullptr;
+CollettIcons *CollettIcons::instance() {
+    if (staticInstance == nullptr) {
+        staticInstance = new CollettIcons();
+        qDebug() << "Constructor: CollettIcons";
+    }
+    return staticInstance;
+}
+
+void CollettIcons::destroy() {
+    if (staticInstance != nullptr) {
+        delete CollettIcons::staticInstance;
+    }
+}
+
+/**!
+ * @brief Construct a CollettIcons object.
+ * 
+ * The icon SVG data is from https://remixicon.com
+ */
+CollettIcons::CollettIcons() {
+
+    // RemixIcon: archive-fill
+    m_svgData["archive"] = QString(
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'>"
+            "<path fill='none' d='M0 0h24v24H0z'/>"
+            "<path d='M3 10h18v10.004c0 .55-.445.996-.993.996H3.993A.994.994 0 0 1 3 20.004V10zm6 "
+            "2v2h6v-2H9zM2 4c0-.552.455-1 .992-1h18.016c.548 0 .992.444.992 1v4H2V4z' "
+            "fill='%1' opacity='%2'/>"
+        "</svg>"
+    );
+
+    // RemixIcon: book-fill
+    m_svgData["book"] = QString(
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'>"
+            "<path fill='none' d='M0 0h24v24H0z'/>"
+            "<path d='M20 22H6.5A3.5 3.5 0 0 1 3 18.5V5a3 3 0 0 1 3-3h14a1 1 0 0 1 1 1v18a1 1 0 0 "
+            "1-1 1zm-1-2v-3H6.5a1.5 1.5 0 0 0 0 3H19z' fill='%1' opacity='%2'/>"
+        "</svg>"
+    );
+
+    // RemixIcon: more-2-fill
+    m_svgData["more"] = QString(
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'>"
+            "<path fill='none' d='M0 0h24v24H0z'/><path d='M12 3c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2"
+            "-.9-2-2-2zm0 14c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-7c-1.1 0-2 .9-2 2s.9 2 "
+            "2 2 2-.9 2-2-.9-2-2-2z' fill='%1' opacity='%2'/>"
+        "</svg>"
+    );
+
+    // RemixIcon: settings-5-fill
+    m_svgData["settings"] = QString(
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'>"
+            "<path fill='none' d='M0 0h24v24H0z'/>"
+            "<path d='M2.132 13.63a9.942 9.942 0 0 1 0-3.26c1.102.026 2.092-.502 2.477-1.431.385-."
+            "93.058-2.004-.74-2.763a9.942 9.942 0 0 1 2.306-2.307c.76.798 1.834 1.125 2.764.74.93-"
+            ".385 1.457-1.376 1.43-2.477a9.942 9.942 0 0 1 3.262 0c-.027 1.102.501 2.092 1.43 2.47"
+            "7.93.385 2.004.058 2.763-.74a9.942 9.942 0 0 1 2.307 2.306c-.798.76-1.125 1.834-.74 2"
+            ".764.385.93 1.376 1.457 2.477 1.43a9.942 9.942 0 0 1 0 3.262c-1.102-.027-2.092.501-2."
+            "477 1.43-.385.93-.058 2.004.74 2.763a9.942 9.942 0 0 1-2.306 2.307c-.76-.798-1.834-1."
+            "125-2.764-.74-.93.385-1.457 1.376-1.43 2.477a9.942 9.942 0 0 1-3.262 0c.027-1.102-.50"
+            "1-2.092-1.43-2.477-.93-.385-2.004-.058-2.763.74a9.942 9.942 0 0 1-2.307-2.306c.798-.7"
+            "6 1.125-1.834.74-2.764-.385-.93-1.376-1.457-2.477-1.43zM12 15a3 3 0 1 0 0-6 3 3 0 0 0"
+            " 0 6z' fill='%1' opacity='%2'/>"
+        "</svg>"
+    );
+}
+
+CollettIcons::~CollettIcons() {
+    qDebug() << "Destructor: CollettIcons";
+}
+
+QIcon CollettIcons::icon(const QString &name) {
+    QColor col = qApp->palette().buttonText().color();
+    QString svg = m_svgData[name].arg(col.name(QColor::HexRgb)).arg("0.8");
+    return QIcon(new SVGIconEngine(svg));
+}
+
+} // namespace Collett

--- a/src/core/icons.h
+++ b/src/core/icons.h
@@ -1,0 +1,53 @@
+/*
+** Collett – Core Icon Repository
+** ==============================
+**
+** This file is a part of Collett
+** Copyright 2020–2021, Veronica Berglyd Olsen
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef COLLETT_ICONS_H
+#define COLLETT_ICONS_H
+
+#include <QHash>
+#include <QIcon>
+#include <QObject>
+#include <QString>
+#include <QByteArray>
+
+namespace Collett {
+
+class CollettIcons : public QObject
+{
+    Q_OBJECT
+
+public:
+    static CollettIcons *instance();
+    static void destroy();
+
+    explicit CollettIcons();
+    ~CollettIcons();
+
+    QIcon icon(const QString &name);
+
+private:
+    static CollettIcons *staticInstance;
+    QHash<QString, QString> m_svgData;
+
+};
+} // namespace Collett
+
+#endif // COLLETT_ICONS_H

--- a/src/core/svgiconengine.cpp
+++ b/src/core/svgiconengine.cpp
@@ -1,0 +1,67 @@
+/*
+** Collett – Core SVG Icon Engine
+** ==============================
+**
+** This file is a part of Collett
+** Copyright 2020–2021, Veronica Berglyd Olsen
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "svgiconengine.h"
+
+#include <QIcon>
+#include <QRect>
+#include <QSize>
+#include <QDebug>
+#include <QPixmap>
+#include <QPainter>
+#include <QByteArray>
+#include <QSvgRenderer>
+
+namespace Collett {
+
+/**
+ * Custom Icon Engine
+ * ==================
+ * Based on: https://stackoverflow.com/a/44757951
+ */
+
+SVGIconEngine::SVGIconEngine(const QString &iconBuffer) {
+    m_iconData = iconBuffer.toLatin1();
+}
+
+void SVGIconEngine::paint(QPainter *painter, const QRect &rect, QIcon::Mode mode, QIcon::State state) {
+    QSvgRenderer renderer(m_iconData);
+    renderer.render(painter, rect);
+}
+
+QIconEngine *SVGIconEngine::clone() const {
+    return new SVGIconEngine(*this);
+}
+
+QPixmap SVGIconEngine::pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state) {
+
+    QImage img(size, QImage::Format_ARGB32);
+    img.fill(qRgba(0, 0, 0, 0));
+    QPixmap pix = QPixmap::fromImage(img, Qt::NoFormatConversion);
+    {
+        QPainter painter(&pix);
+        QRect rect(QPoint(0.0, 0.0), size);
+        this->paint(&painter, rect, mode, state);
+    }
+    return pix;
+}
+
+} // namespace Collett

--- a/src/core/svgiconengine.h
+++ b/src/core/svgiconengine.h
@@ -1,0 +1,51 @@
+/*
+** Collett – Core SVG Icon Engine
+** ==============================
+**
+** This file is a part of Collett
+** Copyright 2020–2021, Veronica Berglyd Olsen
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef SVGICONENGINE_H
+#define SVGICONENGINE_H
+
+#include <QIcon>
+#include <QRect>
+#include <QSize>
+#include <QPixmap>
+#include <QPainter>
+#include <QByteArray>
+#include <QIconEngine>
+
+namespace Collett {
+
+class SVGIconEngine : public QIconEngine
+{
+
+public:
+    explicit SVGIconEngine(const QString &iconBuffer);
+
+    void paint(QPainter *painter, const QRect &rect, QIcon::Mode mode, QIcon::State state) override;
+    QIconEngine *clone() const override;
+    QPixmap pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state) override;
+
+private:
+    QByteArray m_iconData;
+
+};
+} // namespace Collett
+
+#endif // SVGICONENGINE_H

--- a/src/gui/maintoolbar.cpp
+++ b/src/gui/maintoolbar.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "maintoolbar.h"
+#include "icons.h"
 
 #include <QObject>
 #include <QToolBar>
@@ -45,7 +46,7 @@ GuiMainToolBar::GuiMainToolBar(QWidget *parent)
     this->addWidget(stretch1);
     this->addWidget(m_projectName);
     this->addWidget(stretch2);
-    this->addAction(tr("Menu"));
+    this->buildMoreMenu();
 }
 
 void GuiMainToolBar::setProjectName(const QString &name) {
@@ -58,6 +59,8 @@ void GuiMainToolBar::setProjectName(const QString &name) {
  */
 
 void GuiMainToolBar::buildProjectMenu() {
+
+    CollettIcons *icons = CollettIcons::instance();
 
     // Menu
     m_projectMenu = new QMenu(this);
@@ -74,9 +77,27 @@ void GuiMainToolBar::buildProjectMenu() {
     // Assemble
     m_projectButton = new QToolButton(this);
     m_projectButton->setText(tr("Project"));
+    m_projectButton->setIcon(icons->icon("archive"));
     m_projectButton->setMenu(m_projectMenu);
     m_projectButton->setPopupMode(QToolButton::InstantPopup);
     this->addWidget(m_projectButton);
+
+}
+
+void GuiMainToolBar::buildMoreMenu() {
+
+    CollettIcons *icons = CollettIcons::instance();
+
+    // Menu
+    m_moreMenu = new QMenu(this);
+
+    // Assemble
+    m_moreButton = new QToolButton(this);
+    m_moreButton->setText(tr("Menu"));
+    m_moreButton->setIcon(icons->icon("more"));
+    m_moreButton->setMenu(m_moreMenu);
+    m_moreButton->setPopupMode(QToolButton::InstantPopup);
+    this->addWidget(m_moreButton);
 
 }
 

--- a/src/gui/maintoolbar.h
+++ b/src/gui/maintoolbar.h
@@ -45,14 +45,19 @@ public:
 private:
     QLabel *m_projectName;
 
-    // Main Actions
+    // Project Menu
     QToolButton *m_projectButton;
     QMenu       *m_projectMenu;
     QAction     *m_newProject;
     QAction     *m_openProject;
     QAction     *m_saveProject;
 
+    // DropDown Menu
+    QToolButton *m_moreButton;
+    QMenu       *m_moreMenu;
+
     void buildProjectMenu();
+    void buildMoreMenu();
 
 };
 } // namespace Collett

--- a/src/gui/treetoolbar.cpp
+++ b/src/gui/treetoolbar.cpp
@@ -20,10 +20,11 @@
 */
 
 #include "treetoolbar.h"
+#include "icons.h"
 
 #include <QObject>
-#include <QToolBar>
 #include <QWidget>
+#include <QToolBar>
 #include <QSizePolicy>
 
 namespace Collett {
@@ -34,10 +35,12 @@ GuiTreeToolBar::GuiTreeToolBar(QWidget *parent)
     QWidget *stretch = new QWidget(this);
     stretch->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
+    CollettIcons *icons = CollettIcons::instance();
+
     this->setOrientation(Qt::Vertical);
-    this->addAction(tr("Story"));
+    this->addAction(icons->icon("book"), tr("Story"));
     this->addWidget(stretch);
-    this->addAction(tr("Settings"));
+    this->addAction(icons->icon("settings"), tr("Settings"));
 }
 
 } // namespace Collett

--- a/src/guimain.cpp
+++ b/src/guimain.cpp
@@ -124,6 +124,9 @@ bool GuiMain::closeMain() {
     }
     mainConf->flushSettings();
 
+    CollettIcons::destroy();
+    CollettSettings::destroy();
+
     return true;
 }
 

--- a/src/guimain.cpp
+++ b/src/guimain.cpp
@@ -19,14 +19,15 @@
 ** along with this program. If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "guimain.h"
 #include "data.h"
-#include "settings.h"
+#include "doceditor.h"
+#include "guimain.h"
+#include "icons.h"
 #include "maintoolbar.h"
-#include "treetoolbar.h"
+#include "settings.h"
 #include "statusbar.h"
 #include "storytree.h"
-#include "doceditor.h"
+#include "treetoolbar.h"
 
 #include <QString>
 #include <QWidget>

--- a/src/project/project.cpp
+++ b/src/project/project.cpp
@@ -131,9 +131,9 @@ StoryModel *Project::storyModel() {
 }
 
 /**
- * Settings FIle
+ * Settings File
  * =============
- * Load and save functions for the data/project.json file.
+ * Load and save functions for the project/project.json file.
  *
  * This file contains all the meta data and options for the Collett project,
  * except for the project content itself (the documents).
@@ -180,7 +180,7 @@ bool Project::saveSettingsFile() {
 /**
  * Story File
  * ==========
- * Load and save functions for the data/story.json file.
+ * Load and save functions for the project/story.json file.
  *
  * This file contains the structure of StoryItems contained in the StoryModel.
  * The structure is contained as child items under a single root item, and is

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -82,9 +82,15 @@ CollettSettings *CollettSettingsPrivate::instance = nullptr;
 CollettSettings *CollettSettings::instance() {
     if (CollettSettingsPrivate::instance == nullptr) {
         CollettSettingsPrivate::instance = new CollettSettings();
-        qDebug() << "CollettSettings instance created";
+        qDebug() << "Constructor: CollettSettings";
     }
     return CollettSettingsPrivate::instance;
+}
+
+void CollettSettings::destroy() {
+    if (CollettSettingsPrivate::instance != nullptr) {
+        delete CollettSettingsPrivate::instance;
+    }
 }
 
 CollettSettings::CollettSettings()
@@ -109,7 +115,6 @@ CollettSettings::CollettSettings()
 
 CollettSettings::~CollettSettings() {
     qDebug() << "Destructor: CollettSettings";
-    flushSettings();
 }
 
 /**

--- a/src/settings.h
+++ b/src/settings.h
@@ -39,6 +39,7 @@ class CollettSettings : public QObject
 
 public:
     static CollettSettings *instance();
+    static void destroy();
     ~CollettSettings();
 
 private:


### PR DESCRIPTION
**Summary:**

This PR adds a custom icon engine for SVG icons, and a static icons class where the icon SVG is just saved in a QHash map. Four icons have been added for the existing toolbar buttons.

**Related Issue(s):**

Resolves #17 

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [x] Function descriptions are complete and understandable
* [x] Only files that have been actively changed are committed
