### PR TITLE
Change the key format for JSON data files

### DIFF
--- a/sample/project/project.json
+++ b/sample/project/project.json
@@ -1,11 +1,11 @@
 {
-    "meta": {
-        "created": "2021-12-14T22:24:25",
-        "updated": "2021-12-18T18:18:56"
+    "c:meta": {
+        "m:created": "2021-12-14T22:24:25",
+        "m:updated": "2022-01-23T17:54:31"
     },
-    "project": {
-        "projectName": "Sample Project"
+    "c:project": {
+        "u:project-name": "Sample Project"
     },
-    "settings": {
+    "c:settings": {
     }
 }

--- a/sample/project/story.json
+++ b/sample/project/story.json
@@ -1,72 +1,72 @@
 {
-    "type": "ROOT",
-    "xItems": [
+    "u:type": "ROOT",
+    "x:items": [
         {
-            "handle": "e709ba3f-3141-4b4b-95df-4a8d3e91a8ba",
-            "name": "Novel",
-            "order": 0,
-            "type": "BOOK",
-            "wCount": 1234,
-            "xItems": [
+            "m:handle": "e709ba3f-3141-4b4b-95df-4a8d3e91a8ba",
+            "m:order": 0,
+            "m:words": 1234,
+            "u:name": "Novel",
+            "u:type": "BOOK",
+            "x:items": [
                 {
-                    "handle": "c2290a95-ca41-4181-89f2-18cb610ab716",
-                    "name": "Title Page",
-                    "order": 0,
-                    "type": "PAGE",
-                    "wCount": 1234
+                    "m:handle": "c2290a95-ca41-4181-89f2-18cb610ab716",
+                    "m:order": 0,
+                    "m:words": 1234,
+                    "u:name": "Title Page",
+                    "u:type": "PAGE"
                 },
                 {
-                    "handle": "af3dc4a4-5f66-462d-b63b-9c4d7a7dec77",
-                    "name": "Chapter 1",
-                    "order": 1,
-                    "type": "CHAPTER",
-                    "wCount": 1234,
-                    "xItems": [
+                    "m:handle": "af3dc4a4-5f66-462d-b63b-9c4d7a7dec77",
+                    "m:order": 1,
+                    "m:words": 1234,
+                    "u:name": "Chapter 1",
+                    "u:type": "CHAPTER",
+                    "x:items": [
                         {
-                            "handle": "63913842-121f-43ed-8d9c-b3e2432599ab",
-                            "name": "Scene 1.1",
-                            "order": 0,
-                            "type": "SCENE",
-                            "wCount": 1234
+                            "m:handle": "63913842-121f-43ed-8d9c-b3e2432599ab",
+                            "m:order": 0,
+                            "m:words": 1234,
+                            "u:name": "Scene 1.1",
+                            "u:type": "SCENE"
                         },
                         {
-                            "handle": "7e5a1a98-d1a3-44a1-ab4e-2b5d21d92201",
-                            "name": "Scene 1.2",
-                            "order": 1,
-                            "type": "SCENE",
-                            "wCount": 1234
+                            "m:handle": "7e5a1a98-d1a3-44a1-ab4e-2b5d21d92201",
+                            "m:order": 1,
+                            "m:words": 1234,
+                            "u:name": "Scene 1.2",
+                            "u:type": "SCENE"
                         }
                     ]
                 },
                 {
-                    "handle": "61fc6238-87cf-4b78-b2c7-a430776a2b7a",
-                    "name": "Chapter 2",
-                    "order": 2,
-                    "type": "CHAPTER",
-                    "wCount": 1234,
-                    "xItems": [
+                    "m:handle": "61fc6238-87cf-4b78-b2c7-a430776a2b7a",
+                    "m:order": 2,
+                    "m:words": 1234,
+                    "u:name": "Chapter 2",
+                    "u:type": "CHAPTER",
+                    "x:items": [
                         {
-                            "handle": "f3993444-4e43-4ace-bfdb-55ca659ca914",
-                            "name": "Scene 2.1",
-                            "order": 0,
-                            "type": "SCENE",
-                            "wCount": 1234
+                            "m:handle": "f3993444-4e43-4ace-bfdb-55ca659ca914",
+                            "m:order": 0,
+                            "m:words": 1234,
+                            "u:name": "Scene 2.1",
+                            "u:type": "SCENE"
                         },
                         {
-                            "handle": "ab6ba4f4-5658-4ff0-941d-2e0c687fe88d",
-                            "name": "Scene 2.2",
-                            "order": 1,
-                            "type": "SCENE",
-                            "wCount": 1234
+                            "m:handle": "ab6ba4f4-5658-4ff0-941d-2e0c687fe88d",
+                            "m:order": 1,
+                            "m:words": 1234,
+                            "u:name": "Scene 2.2",
+                            "u:type": "SCENE"
                         }
                     ]
                 },
                 {
-                    "handle": "f1dffe99-3583-4f9c-9f0b-1a8f323b0670",
-                    "name": "Very long title on this element here",
-                    "order": 3,
-                    "type": "PAGE",
-                    "wCount": 1234
+                    "m:handle": "f1dffe99-3583-4f9c-9f0b-1a8f323b0670",
+                    "m:order": 3,
+                    "m:words": 1234,
+                    "u:name": "Very long title on this element here",
+                    "u:type": "PAGE"
                 }
             ]
         }

--- a/src/core/storage.cpp
+++ b/src/core/storage.cpp
@@ -181,7 +181,7 @@ QString Storage::lastError() const {
  * @param def    the default value to return in case the key does not exist.
  * @return the value or the default as a string.
  */
-QString Storage::getJsonString(const QJsonObject &object, const QString &key, QString def) {
+QString Storage::getJsonString(const QJsonObject &object, const QLatin1String &key, QString def) {
     if (object.contains(key)) {
         return object.value(key).toString();
     } else {

--- a/src/core/storage.h
+++ b/src/core/storage.h
@@ -27,6 +27,7 @@
 #include <QObject>
 #include <QString>
 #include <QJsonObject>
+#include <QLatin1String>
 
 namespace Collett {
 
@@ -56,7 +57,7 @@ public:
 
     // Static Methods
 
-    static QString getJsonString(const QJsonObject &object, const QString &key, QString def);
+    static QString getJsonString(const QJsonObject &object, const QLatin1String &key, QString def);
 
 private:
     bool readJson(const QString &filePath, QJsonObject &fileData);

--- a/src/project/project.cpp
+++ b/src/project/project.cpp
@@ -33,6 +33,7 @@
 #include <QByteArray>
 #include <QTextStream>
 #include <QJsonDocument>
+#include <QLatin1String>
 #include <QJsonParseError>
 
 namespace Collett {
@@ -81,7 +82,7 @@ bool Project::openProject() {
     if (main) {
         bool settings = loadSettingsFile();
         bool story = loadStoryFile();
-        m_isValid = settings & story;
+        m_isValid = settings && story;
     } else {
         m_isValid = false;
     }
@@ -101,7 +102,7 @@ bool Project::saveProject() {
     bool settings = saveSettingsFile();
     bool story = saveStoryFile();
 
-    return main & settings & story;
+    return main && settings && story;
 }
 
 bool Project::isValid() const {
@@ -147,12 +148,12 @@ bool Project::loadSettingsFile() {
         return false;
     }
 
-    QJsonObject jMeta = jData["meta"].toObject();
-    QJsonObject jProject = jData["project"].toObject();
-    QJsonObject jSettings = jData["settings"].toObject();
+    QJsonObject jMeta = jData[QLatin1String("c:meta")].toObject();
+    QJsonObject jProject = jData[QLatin1String("c:project")].toObject();
+    QJsonObject jSettings = jData[QLatin1String("c:settings")].toObject();
 
-    m_createdTime = Storage::getJsonString(jMeta, "created", "Unknown");
-    m_projectName = Storage::getJsonString(jProject, "projectName", tr("Unnamed Project"));
+    m_createdTime = Storage::getJsonString(jMeta, QLatin1String("m:created"), "Unknown");
+    m_projectName = Storage::getJsonString(jProject, QLatin1String("u:project-name"), tr("Unnamed Project"));
 
     return true;
 }
@@ -161,14 +162,14 @@ bool Project::saveSettingsFile() {
 
     QJsonObject jData, jMeta, jProject, jSettings;
 
-    jMeta["created"] = m_createdTime;
-    jMeta["updated"] = QDateTime::currentDateTime().toString(Qt::ISODate);
+    jMeta[QLatin1String("m:created")] = m_createdTime;
+    jMeta[QLatin1String("m:updated")] = QDateTime::currentDateTime().toString(Qt::ISODate);
 
-    jProject["projectName"] = m_projectName;
+    jProject[QLatin1String("u:project-name")] = m_projectName;
 
-    jData["meta"] = jMeta;
-    jData["project"] = jProject;
-    jData["settings"] = jSettings;
+    jData[QLatin1String("c:meta")] = jMeta;
+    jData[QLatin1String("c:project")] = jProject;
+    jData[QLatin1String("c:settings")] = jSettings;
 
     if (!m_store->saveFile("project", jData)) {
         m_lastError = m_store->lastError();

--- a/src/project/storyitem.cpp
+++ b/src/project/storyitem.cpp
@@ -29,6 +29,7 @@
 #include <QJsonValue>
 #include <QJsonObject>
 #include <QVariantList>
+#include <QLatin1String>
 
 namespace Collett {
 
@@ -105,17 +106,17 @@ StoryItem *StoryItem::addChild(const QJsonObject &json) {
     ItemType type   = StoryItem::Invalid;
     int      wCount = 0;
 
-    if (json.contains("handle")) {
-        handle = QUuid(json["handle"].toString());
+    if (json.contains(QLatin1String("m:handle"))) {
+        handle = QUuid(json[QLatin1String("m:handle")].toString());
     }
-    if (json.contains("name")) {
-        name = json["name"].toString();
+    if (json.contains(QLatin1String("u:name"))) {
+        name = json[QLatin1String("u:name")].toString();
     }
-    if (json.contains("type")) {
-        type = StoryItem::typeFromString(json["type"].toString());
+    if (json.contains(QLatin1String("u:type"))) {
+        type = StoryItem::typeFromString(json[QLatin1String("u:type")].toString());
     }
-    if (json.contains("wCount")) {
-        wCount = json["wCount"].toInt();
+    if (json.contains(QLatin1String("m:words"))) {
+        wCount = json[QLatin1String("m:words")].toInt();
     }
 
     if (type == StoryItem::Invalid) {
@@ -146,9 +147,9 @@ StoryItem *StoryItem::addChild(const QJsonObject &json) {
     item->setWordCount(wCount);
     m_childItems.append(item);
 
-    if (json.contains("xItems")) {
-        if (json["xItems"].isArray()) {
-            for (const QJsonValue &value : json["xItems"].toArray()) {
+    if (json.contains(QLatin1String("x:items"))) {
+        if (json[QLatin1String("x:items")].isArray()) {
+            for (const QJsonValue &value : json[QLatin1String("x:items")].toArray()) {
                 if (value.isObject()) {
                     item->addChild(value.toObject());
                 } else {
@@ -178,30 +179,30 @@ QJsonObject StoryItem::toJsonObject() {
         children.append(m_childItems.at(i)->toJsonObject());
     }
 
-    QString type = "UNKNOWN";
+    QLatin1String type;
     switch (m_type) {
-        case StoryItem::Root:      type = "ROOT"; break;
-        case StoryItem::Book:      type = "BOOK"; break;
-        case StoryItem::Partition: type = "PARTITION"; break;
-        case StoryItem::Chapter:   type = "CHAPTER"; break;
-        case StoryItem::Scene:     type = "SCENE"; break;
-        case StoryItem::Page:      type = "PAGE"; break;
+        case StoryItem::Root:      type = QLatin1String("ROOT"); break;
+        case StoryItem::Book:      type = QLatin1String("BOOK"); break;
+        case StoryItem::Partition: type = QLatin1String("PARTITION"); break;
+        case StoryItem::Chapter:   type = QLatin1String("CHAPTER"); break;
+        case StoryItem::Scene:     type = QLatin1String("SCENE"); break;
+        case StoryItem::Page:      type = QLatin1String("PAGE"); break;
         case StoryItem::Invalid:
             return QJsonObject();
             break;
     }
 
     if (!m_parentItem) {
-        item["type"]   = type;
-        item["xItems"] = children;
+        item[QLatin1String("u:type")]  = type;
+        item[QLatin1String("x:items")] = children;
     } else {
-        item["handle"] = m_handle.toString(QUuid::WithoutBraces);
-        item["name"]   = m_name;
-        item["type"]   = type;
-        item["order"]  = row();
-        item["wCount"] = m_wCount;
+        item[QLatin1String("m:handle")] = m_handle.toString(QUuid::WithoutBraces);
+        item[QLatin1String("m:order")]  = row();
+        item[QLatin1String("m:words")]  = m_wCount;
+        item[QLatin1String("u:name")]   = m_name;
+        item[QLatin1String("u:type")]   = type;
         if (children.size() > 0) {
-            item["xItems"] = children;
+            item[QLatin1String("x:items")] = children;
         }
     }
 

--- a/src/project/storymodel.cpp
+++ b/src/project/storymodel.cpp
@@ -29,6 +29,7 @@
 #include <QJsonValue>
 #include <QJsonObject>
 #include <QModelIndex>
+#include <QLatin1String>
 #include <QAbstractItemModel>
 
 namespace Collett {
@@ -90,28 +91,28 @@ bool StoryModel::fromJsonObject(const QJsonObject &json) {
         qWarning() << "StoryItem Root: No data in JSON object";
         return false;
     }
-    if (!json.contains("type")) {
+    if (!json.contains(QLatin1String("u:type"))) {
         qWarning() << "StoryItem Root: Not a valid story item JSON object";
         return false;
     }
 
-    StoryItem::ItemType type = StoryItem::typeFromString(json["type"].toString());
+    StoryItem::ItemType type = StoryItem::typeFromString(json[QLatin1String("u:type")].toString());
     if (type != StoryItem::Root) {
         qWarning() << "StoryItem Root: No ROOT item found in JSON object";
         return false;
     }
 
-    if (!json.contains("xItems")) {
+    if (!json.contains(QLatin1String("x:items"))) {
         qDebug() << "StoryItem Root: No items found in JSON object";
         return false;
     }
-    if (!json["xItems"].isArray()) {
-        qWarning() << "StoryItem Root: xItems value is not a JSON array";
+    if (!json[QLatin1String("x:items")].isArray()) {
+        qWarning() << "StoryItem Root: x:items value is not a JSON array";
         return false;
     }
 
     emit beginResetModel();
-    for (const QJsonValue &value : json["xItems"].toArray()) {
+    for (const QJsonValue &value : json[QLatin1String("x:items")].toArray()) {
         if (value.isObject()) {
             m_rootItem->addChild(value.toObject());
         } else {


### PR DESCRIPTION
**Summary:**

Add a name space-like prefix to JSON values. It consists of the following prefixes:
* `c:` container object
* `m:` meta data value
* `u:` user defined data value
* `x:` array of sub-objects

Since the Qt implementation of JSON sorts the entries alphabetically, this both helps to group them in the JSON file, and also creates a logical order with containers first, then meta data, then user data, and then sub-elements.

**Related Issue(s):**

No issues related to this PR.

**Reviewer's Checklist:**

* [ ] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] Function descriptions are complete and understandable
* [ ] Only files that have been actively changed are committed
