### PR TITLE
Add documents dropdown menu

### DIFF
--- a/i18n/collett_en_US.ts
+++ b/i18n/collett_en_US.ts
@@ -112,7 +112,7 @@
 <context>
     <name>Collett::GuiMain</name>
     <message>
-        <location filename="../src/guimain.cpp" line="78"/>
+        <location filename="../src/guimain.cpp" line="94"/>
         <source>%1 %2 Version %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -120,52 +120,57 @@
 <context>
     <name>Collett::GuiMainToolBar</name>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="42"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="43"/>
         <source>No Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="68"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
         <source>New Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="72"/>
         <source>Open Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="70"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="75"/>
         <source>Save Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="73"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="79"/>
         <source>Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="82"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="88"/>
         <source>New Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="83"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="91"/>
         <source>Open Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="84"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="94"/>
         <source>Save Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="87"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="97"/>
+        <source>Rename Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="101"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="104"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="118"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -173,75 +178,70 @@
 <context>
     <name>Collett::GuiStoryTree</name>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="58"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/storytree.cpp" line="119"/>
+        <location filename="../src/gui/storytree.cpp" line="134"/>
         <source>Add Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="121"/>
         <location filename="../src/gui/storytree.cpp" line="136"/>
         <location filename="../src/gui/storytree.cpp" line="151"/>
         <location filename="../src/gui/storytree.cpp" line="166"/>
         <location filename="../src/gui/storytree.cpp" line="181"/>
+        <location filename="../src/gui/storytree.cpp" line="196"/>
         <source>Inside</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="125"/>
         <location filename="../src/gui/storytree.cpp" line="140"/>
         <location filename="../src/gui/storytree.cpp" line="155"/>
         <location filename="../src/gui/storytree.cpp" line="170"/>
         <location filename="../src/gui/storytree.cpp" line="185"/>
+        <location filename="../src/gui/storytree.cpp" line="200"/>
         <source>Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="127"/>
         <location filename="../src/gui/storytree.cpp" line="142"/>
         <location filename="../src/gui/storytree.cpp" line="157"/>
         <location filename="../src/gui/storytree.cpp" line="172"/>
         <location filename="../src/gui/storytree.cpp" line="187"/>
+        <location filename="../src/gui/storytree.cpp" line="202"/>
         <source>After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="134"/>
+        <location filename="../src/gui/storytree.cpp" line="149"/>
         <source>Add Chapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="149"/>
+        <location filename="../src/gui/storytree.cpp" line="164"/>
         <source>Add Partition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="164"/>
+        <location filename="../src/gui/storytree.cpp" line="179"/>
         <source>Add Book</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="166"/>
+        <location filename="../src/gui/storytree.cpp" line="181"/>
         <source>Here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="179"/>
+        <location filename="../src/gui/storytree.cpp" line="194"/>
         <source>Add Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="216"/>
+        <location filename="../src/gui/storytree.cpp" line="231"/>
         <source>Rename Story Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="216"/>
-        <source>New name:</source>
+        <location filename="../src/gui/storytree.cpp" line="231"/>
+        <source>New Name:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/collett_en_US.ts
+++ b/i18n/collett_en_US.ts
@@ -125,27 +125,47 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="68"/>
         <source>New Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="72"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
         <source>Open Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="75"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="70"/>
         <source>Save Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="79"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="73"/>
         <source>Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="96"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="82"/>
+        <source>New Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="83"/>
+        <source>Open Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="84"/>
+        <source>Save Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="87"/>
+        <source>Documents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="104"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/collett_nb_NO.ts
+++ b/i18n/collett_nb_NO.ts
@@ -112,7 +112,7 @@
 <context>
     <name>Collett::GuiMain</name>
     <message>
-        <location filename="../src/guimain.cpp" line="78"/>
+        <location filename="../src/guimain.cpp" line="94"/>
         <source>%1 %2 Version %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -120,52 +120,57 @@
 <context>
     <name>Collett::GuiMainToolBar</name>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="42"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="43"/>
         <source>No Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="68"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
         <source>New Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="72"/>
         <source>Open Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="70"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="75"/>
         <source>Save Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="73"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="79"/>
         <source>Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="82"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="88"/>
         <source>New Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="83"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="91"/>
         <source>Open Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="84"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="94"/>
         <source>Save Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="87"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="97"/>
+        <source>Rename Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="101"/>
         <source>Documents</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="104"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="118"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -173,75 +178,70 @@
 <context>
     <name>Collett::GuiStoryTree</name>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="58"/>
-        <source>Rename</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/storytree.cpp" line="119"/>
+        <location filename="../src/gui/storytree.cpp" line="134"/>
         <source>Add Scene</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="121"/>
         <location filename="../src/gui/storytree.cpp" line="136"/>
         <location filename="../src/gui/storytree.cpp" line="151"/>
         <location filename="../src/gui/storytree.cpp" line="166"/>
         <location filename="../src/gui/storytree.cpp" line="181"/>
+        <location filename="../src/gui/storytree.cpp" line="196"/>
         <source>Inside</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="125"/>
         <location filename="../src/gui/storytree.cpp" line="140"/>
         <location filename="../src/gui/storytree.cpp" line="155"/>
         <location filename="../src/gui/storytree.cpp" line="170"/>
         <location filename="../src/gui/storytree.cpp" line="185"/>
+        <location filename="../src/gui/storytree.cpp" line="200"/>
         <source>Before</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="127"/>
         <location filename="../src/gui/storytree.cpp" line="142"/>
         <location filename="../src/gui/storytree.cpp" line="157"/>
         <location filename="../src/gui/storytree.cpp" line="172"/>
         <location filename="../src/gui/storytree.cpp" line="187"/>
+        <location filename="../src/gui/storytree.cpp" line="202"/>
         <source>After</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="134"/>
+        <location filename="../src/gui/storytree.cpp" line="149"/>
         <source>Add Chapter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="149"/>
+        <location filename="../src/gui/storytree.cpp" line="164"/>
         <source>Add Partition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="164"/>
+        <location filename="../src/gui/storytree.cpp" line="179"/>
         <source>Add Book</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="166"/>
+        <location filename="../src/gui/storytree.cpp" line="181"/>
         <source>Here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="179"/>
+        <location filename="../src/gui/storytree.cpp" line="194"/>
         <source>Add Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="216"/>
+        <location filename="../src/gui/storytree.cpp" line="231"/>
         <source>Rename Story Item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/storytree.cpp" line="216"/>
-        <source>New name:</source>
+        <location filename="../src/gui/storytree.cpp" line="231"/>
+        <source>New Name:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/i18n/collett_nb_NO.ts
+++ b/i18n/collett_nb_NO.ts
@@ -125,27 +125,47 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="68"/>
         <source>New Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="72"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="69"/>
         <source>Open Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="75"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="70"/>
         <source>Save Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="79"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="73"/>
         <source>Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/maintoolbar.cpp" line="96"/>
+        <location filename="../src/gui/maintoolbar.cpp" line="82"/>
+        <source>New Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="83"/>
+        <source>Open Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="84"/>
+        <source>Save Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="87"/>
+        <source>Documents</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/maintoolbar.cpp" line="104"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/core/icons.cpp
+++ b/src/core/icons.cpp
@@ -111,6 +111,12 @@ CollettIcons::CollettIcons() {
         "H11v2z"
     );
 
+    // description_black_24dp.svg
+    m_svgPath["documents"] = QByteArray(
+        "M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8"
+        "v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+    );
+
     // format_size_black_24dp.svg
     m_svgPath["formatText"] = QByteArray(
         "M9 4v3h5v12h3V7h5V4H9zm-6 8h3v7h3v-7h3V9H3v3z"

--- a/src/editor/doceditor.cpp
+++ b/src/editor/doceditor.cpp
@@ -34,6 +34,7 @@
 #include <QWidget>
 #include <QJsonObject>
 #include <QVBoxLayout>
+#include <QApplication>
 #include <QTextCharFormat>
 
 namespace Collett {
@@ -181,6 +182,15 @@ QUuid GuiDocEditor::currentDocument() const {
 
 bool GuiDocEditor::hasDocument() const {
     return m_document != nullptr && !m_docUuid.isNull();
+}
+
+/**!
+ * @brief Check if this, or any child widget has focus
+ */
+bool GuiDocEditor::anyFocus() const {
+    if (this->hasFocus())
+        return true;
+    return this->isAncestorOf(qApp->focusWidget());
 }
 
 /**

--- a/src/editor/doceditor.h
+++ b/src/editor/doceditor.h
@@ -55,6 +55,7 @@ public:
 
     QUuid currentDocument() const;
     bool hasDocument() const;
+    bool anyFocus() const;
 
 signals:
     void popMessage(const Collett::Severity type, const QString &message);

--- a/src/gui/maintoolbar.cpp
+++ b/src/gui/maintoolbar.cpp
@@ -94,6 +94,9 @@ void GuiMainToolBar::buildMainMenu() {
     m_saveDocument = m_docsMenu->addAction(tr("Save Document"));
     m_saveDocument->setShortcut(QKeySequence("Ctrl+S"));
 
+    m_renameDocument = m_docsMenu->addAction(tr("Rename Document"));
+    m_renameDocument->setShortcut(QKeySequence("F2"));
+
     m_docsButton = new QToolButton(this);
     m_docsButton->setText(tr("Documents"));
     m_docsButton->setIcon(icons->icon("documents"));

--- a/src/gui/maintoolbar.cpp
+++ b/src/gui/maintoolbar.cpp
@@ -22,12 +22,13 @@
 #include "maintoolbar.h"
 #include "icons.h"
 
-#include <QObject>
-#include <QToolBar>
-#include <QWidget>
-#include <QSizePolicy>
-#include <QAction>
 #include <QMenu>
+#include <QAction>
+#include <QObject>
+#include <QWidget>
+#include <QToolBar>
+#include <QSizePolicy>
+#include <QKeySequence>
 
 namespace Collett {
 
@@ -66,8 +67,13 @@ void GuiMainToolBar::buildMainMenu() {
     m_projectMenu = new QMenu(this);
 
     m_newProject = m_projectMenu->addAction(tr("New Project"));
+    m_newProject->setShortcut(QKeySequence("Ctrl+Shift+N"));
+
     m_openProject = m_projectMenu->addAction(tr("Open Project"));
+    m_openProject->setShortcut(QKeySequence("Ctrl+Shift+O"));
+
     m_saveProject = m_projectMenu->addAction(tr("Save Project"));
+    m_saveProject->setShortcut(QKeySequence("Ctrl+Shift+S"));
 
     m_projectButton = new QToolButton(this);
     m_projectButton->setText(tr("Project"));
@@ -80,8 +86,13 @@ void GuiMainToolBar::buildMainMenu() {
     m_docsMenu = new QMenu(this);
 
     m_newDocument = m_docsMenu->addAction(tr("New Document"));
+    m_newDocument->setShortcut(QKeySequence("Ctrl+N"));
+
     m_openDocument = m_docsMenu->addAction(tr("Open Document"));
+    m_openDocument->setShortcut(QKeySequence("Ctrl+O"));
+
     m_saveDocument = m_docsMenu->addAction(tr("Save Document"));
+    m_saveDocument->setShortcut(QKeySequence("Ctrl+S"));
 
     m_docsButton = new QToolButton(this);
     m_docsButton->setText(tr("Documents"));

--- a/src/gui/maintoolbar.cpp
+++ b/src/gui/maintoolbar.cpp
@@ -42,7 +42,7 @@ GuiMainToolBar::GuiMainToolBar(QWidget *parent)
     m_projectName = new QLabel(tr("No Project"));
 
     this->setOrientation(Qt::Horizontal);
-    this->buildProjectMenu();
+    this->buildMainMenu();
     this->addWidget(stretch1);
     this->addWidget(m_projectName);
     this->addWidget(stretch2);
@@ -58,29 +58,37 @@ void GuiMainToolBar::setProjectName(const QString &name) {
  * ===============
  */
 
-void GuiMainToolBar::buildProjectMenu() {
+void GuiMainToolBar::buildMainMenu() {
 
     CollettIcons *icons = CollettIcons::instance();
 
-    // Menu
+    // Project Menu
     m_projectMenu = new QMenu(this);
 
-    // New Project
     m_newProject = m_projectMenu->addAction(tr("New Project"));
-
-    // Open Project
     m_openProject = m_projectMenu->addAction(tr("Open Project"));
-
-    // Save Project
     m_saveProject = m_projectMenu->addAction(tr("Save Project"));
 
-    // Assemble
     m_projectButton = new QToolButton(this);
     m_projectButton->setText(tr("Project"));
     m_projectButton->setIcon(icons->icon("archive"));
     m_projectButton->setMenu(m_projectMenu);
     m_projectButton->setPopupMode(QToolButton::InstantPopup);
     this->addWidget(m_projectButton);
+
+    // Documents Menu
+    m_docsMenu = new QMenu(this);
+
+    m_newDocument = m_docsMenu->addAction(tr("New Document"));
+    m_openDocument = m_docsMenu->addAction(tr("Open Document"));
+    m_saveDocument = m_docsMenu->addAction(tr("Save Document"));
+
+    m_docsButton = new QToolButton(this);
+    m_docsButton->setText(tr("Documents"));
+    m_docsButton->setIcon(icons->icon("documents"));
+    m_docsButton->setMenu(m_docsMenu);
+    m_docsButton->setPopupMode(QToolButton::InstantPopup);
+    this->addWidget(m_docsButton);
 
 }
 

--- a/src/gui/maintoolbar.h
+++ b/src/gui/maintoolbar.h
@@ -59,6 +59,7 @@ private:
     QAction     *m_newDocument;
     QAction     *m_openDocument;
     QAction     *m_saveDocument;
+    QAction     *m_renameDocument;
 
     // DropDown Menu
     QToolButton *m_moreButton;

--- a/src/gui/maintoolbar.h
+++ b/src/gui/maintoolbar.h
@@ -52,11 +52,18 @@ private:
     QAction     *m_openProject;
     QAction     *m_saveProject;
 
+    // Documents Menu
+    QToolButton *m_docsButton;
+    QMenu       *m_docsMenu;
+    QAction     *m_newDocument;
+    QAction     *m_openDocument;
+    QAction     *m_saveDocument;
+
     // DropDown Menu
     QToolButton *m_moreButton;
     QMenu       *m_moreMenu;
 
-    void buildProjectMenu();
+    void buildMainMenu();
     void buildMoreMenu();
 
 };

--- a/src/gui/maintoolbar.h
+++ b/src/gui/maintoolbar.h
@@ -32,6 +32,7 @@
 
 namespace Collett {
 
+class GuiMain;
 class GuiMainToolBar : public QToolBar
 {
     Q_OBJECT
@@ -65,6 +66,8 @@ private:
 
     void buildMainMenu();
     void buildMoreMenu();
+
+    friend class GuiMain;
 
 };
 } // namespace Collett

--- a/src/gui/storytree.cpp
+++ b/src/gui/storytree.cpp
@@ -33,6 +33,7 @@
 #include <QModelIndex>
 #include <QInputDialog>
 #include <QKeySequence>
+#include <QModelIndexList>
 
 namespace Collett {
 
@@ -75,6 +76,20 @@ GuiStoryTree::GuiStoryTree(QWidget *parent)
 void GuiStoryTree::setTreeModel(StoryModel *model) {
     m_model = model;
     this->setModel(m_model);
+}
+
+/**
+ * Class Getters
+ * =============
+ */
+
+QModelIndex GuiStoryTree::firstSelectedIndex() {
+    QModelIndexList selections = this->selectedIndexes();
+    if (!selections.isEmpty()) {
+        return selections.at(0);
+    } else {
+        return QModelIndex();
+    }
 }
 
 /**

--- a/src/gui/storytree.cpp
+++ b/src/gui/storytree.cpp
@@ -55,13 +55,6 @@ GuiStoryTree::GuiStoryTree(QWidget *parent)
     this->setAlternatingRowColors(true);
     this->setExpandsOnDoubleClick(false);
 
-    // Item Actions
-    m_editItem = new QAction(tr("Rename"), this);
-    m_editItem->setShortcut(QKeySequence("F2"));
-    this->addAction(m_editItem);
-    connect(m_editItem, SIGNAL(triggered(bool)),
-            this, SLOT(doEditName(bool)));
-
     // Connect the Context Menu
     this->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, SIGNAL(customContextMenuRequested(QPoint)),
@@ -217,21 +210,21 @@ void GuiStoryTree::doOpenContextMenu(const QPoint &pos) {
 void GuiStoryTree::doEditName(bool checked) {
     Q_UNUSED(checked);
 
-    QModelIndexList sel = this->selectedIndexes();
-    if (sel.size() < 1) {
+    QModelIndex index = this->firstSelectedIndex();
+    if (!index.isValid()) {
         qDebug() << "No item selected";
         return;
     }
 
-    QString oldName = m_model->itemName(sel.at(0));
+    QString oldName = m_model->itemName(index);
     qDebug() << "Requested rename of item" << oldName;
 
     bool ok;
     QString newName = QInputDialog::getText(
-        this, tr("Rename Story Item"), tr("New name:"), QLineEdit::Normal, oldName, &ok
+        this, tr("Rename Story Item"), tr("New Name:"), QLineEdit::Normal, oldName, &ok
     );
     if (ok && !newName.isEmpty()) {
-        m_model->setItemName(sel.at(0), newName);
+        m_model->setItemName(index, newName);
     }
 }
 

--- a/src/gui/storytree.h
+++ b/src/gui/storytree.h
@@ -48,6 +48,10 @@ public:
 
     void setTreeModel(StoryModel *model);
 
+    // Class Getters
+
+    QModelIndex firstSelectedIndex();
+
 private slots:
     void doEditName(bool checked);
     void doOpenContextMenu(const QPoint &pos);

--- a/src/gui/storytree.h
+++ b/src/gui/storytree.h
@@ -52,8 +52,10 @@ public:
 
     QModelIndex firstSelectedIndex();
 
-private slots:
+public slots:
     void doEditName(bool checked);
+
+private slots:
     void doOpenContextMenu(const QPoint &pos);
     void doAddChild(StoryItem *item, StoryItem::ItemType type, StoryModel::AddLocation loc);
 

--- a/src/guimain.cpp
+++ b/src/guimain.cpp
@@ -73,6 +73,19 @@ GuiMain::GuiMain(QWidget *parent) : QMainWindow(parent) {
     connect(m_storyTree, SIGNAL(doubleClicked(const QModelIndex&)),
             this, SLOT(storyTreeDoubleClick(const QModelIndex&)));
 
+    connect(m_mainToolBar->m_openDocument, SIGNAL(triggered()),
+            this, SLOT(openSelectedDocument()));
+    connect(m_mainToolBar->m_saveDocument, SIGNAL(triggered()),
+            this, SLOT(saveOpenDocument()));
+
+    // Connect Actions to Capture Key Sequence
+    this->addAction(m_mainToolBar->m_newProject);
+    this->addAction(m_mainToolBar->m_openProject);
+    this->addAction(m_mainToolBar->m_saveProject);
+    this->addAction(m_mainToolBar->m_newDocument);
+    this->addAction(m_mainToolBar->m_openDocument);
+    this->addAction(m_mainToolBar->m_saveDocument);
+
     // Finalise
     setWindowTitle(
         tr("%1 %2 Version %3").arg(qApp->applicationName(), "–", qApp->applicationVersion())
@@ -194,6 +207,24 @@ void GuiMain::closeEvent(QCloseEvent *event) {
  * Private Slots
  * =============
  */
+
+void GuiMain::openSelectedDocument() {
+    if (!m_data->hasProject())
+        return;
+
+    QModelIndex index = m_storyTree->firstSelectedIndex();
+    if (!index.isValid())
+        return;
+
+    this->openDocument(m_data->project()->storyModel()->itemHandle(index));
+}
+
+void GuiMain::saveOpenDocument() {
+    if (!m_data->hasProject())
+        return;
+    if (m_docEditor->anyFocus())
+        m_docEditor->saveDocument();
+}
 
 void GuiMain::storyTreeDoubleClick(const QModelIndex &index) {
     if (!m_data->hasProject() || !index.isValid()) {

--- a/src/guimain.cpp
+++ b/src/guimain.cpp
@@ -77,6 +77,8 @@ GuiMain::GuiMain(QWidget *parent) : QMainWindow(parent) {
             this, SLOT(openSelectedDocument()));
     connect(m_mainToolBar->m_saveDocument, SIGNAL(triggered()),
             this, SLOT(saveOpenDocument()));
+    connect(m_mainToolBar->m_renameDocument, SIGNAL(triggered()),
+            this, SLOT(renameDocument()));
 
     // Connect Actions to Capture Key Sequence
     this->addAction(m_mainToolBar->m_newProject);
@@ -85,6 +87,7 @@ GuiMain::GuiMain(QWidget *parent) : QMainWindow(parent) {
     this->addAction(m_mainToolBar->m_newDocument);
     this->addAction(m_mainToolBar->m_openDocument);
     this->addAction(m_mainToolBar->m_saveDocument);
+    this->addAction(m_mainToolBar->m_renameDocument);
 
     // Finalise
     setWindowTitle(
@@ -224,6 +227,12 @@ void GuiMain::saveOpenDocument() {
         return;
     if (m_docEditor->anyFocus())
         m_docEditor->saveDocument();
+}
+
+void GuiMain::renameDocument() {
+    if (!m_data->hasProject())
+        return;
+    m_storyTree->doEditName(false);
 }
 
 void GuiMain::storyTreeDoubleClick(const QModelIndex &index) {

--- a/src/guimain.h
+++ b/src/guimain.h
@@ -82,6 +82,8 @@ private:
 
 private slots:
 
+    void openSelectedDocument();
+    void saveOpenDocument();
     void storyTreeDoubleClick(const QModelIndex &index);
 
 };

--- a/src/guimain.h
+++ b/src/guimain.h
@@ -84,6 +84,7 @@ private slots:
 
     void openSelectedDocument();
     void saveOpenDocument();
+    void renameDocument();
     void storyTreeDoubleClick(const QModelIndex &index);
 
 };


### PR DESCRIPTION
**Summary:**

Adds a documents dropdown menu to the main toolbar, and connects open, save and rename.

**Related Issue(s):**

Resolves #32

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] Function descriptions are complete and understandable
* [x] Only files that have been actively changed are committed
