### PR TITLE
Allow for saving the story tree state

### DIFF
--- a/sample/project/story.json
+++ b/sample/project/story.json
@@ -2,6 +2,7 @@
 	"u:type": "ROOT",
 	"x:items": [
 		{
+			"m:expanded": false,
 			"m:handle": "e709ba3f-3141-4b4b-95df-4a8d3e91a8ba",
 			"m:order": 0,
 			"m:words": 1234,
@@ -9,6 +10,7 @@
 			"u:type": "BOOK",
 			"x:items": [
 				{
+					"m:expanded": false,
 					"m:handle": "c2290a95-ca41-4181-89f2-18cb610ab716",
 					"m:order": 0,
 					"m:words": 1234,
@@ -16,6 +18,7 @@
 					"u:type": "PAGE"
 				},
 				{
+					"m:expanded": false,
 					"m:handle": "af3dc4a4-5f66-462d-b63b-9c4d7a7dec77",
 					"m:order": 1,
 					"m:words": 1234,
@@ -23,6 +26,7 @@
 					"u:type": "CHAPTER",
 					"x:items": [
 						{
+							"m:expanded": false,
 							"m:handle": "63913842-121f-43ed-8d9c-b3e2432599ab",
 							"m:order": 0,
 							"m:words": 1234,
@@ -30,6 +34,7 @@
 							"u:type": "SCENE"
 						},
 						{
+							"m:expanded": false,
 							"m:handle": "7e5a1a98-d1a3-44a1-ab4e-2b5d21d92201",
 							"m:order": 1,
 							"m:words": 1234,
@@ -39,6 +44,7 @@
 					]
 				},
 				{
+					"m:expanded": false,
 					"m:handle": "61fc6238-87cf-4b78-b2c7-a430776a2b7a",
 					"m:order": 2,
 					"m:words": 1234,
@@ -46,6 +52,7 @@
 					"u:type": "CHAPTER",
 					"x:items": [
 						{
+							"m:expanded": false,
 							"m:handle": "f3993444-4e43-4ace-bfdb-55ca659ca914",
 							"m:order": 0,
 							"m:words": 1234,
@@ -53,6 +60,7 @@
 							"u:type": "SCENE"
 						},
 						{
+							"m:expanded": false,
 							"m:handle": "ab6ba4f4-5658-4ff0-941d-2e0c687fe88d",
 							"m:order": 1,
 							"m:words": 1234,
@@ -62,6 +70,7 @@
 					]
 				},
 				{
+					"m:expanded": false,
 					"m:handle": "f1dffe99-3583-4f9c-9f0b-1a8f323b0670",
 					"m:order": 3,
 					"m:words": 1234,

--- a/sample/project/story.json
+++ b/sample/project/story.json
@@ -2,7 +2,7 @@
 	"u:type": "ROOT",
 	"x:items": [
 		{
-			"m:expanded": false,
+			"m:expanded": true,
 			"m:handle": "e709ba3f-3141-4b4b-95df-4a8d3e91a8ba",
 			"m:order": 0,
 			"m:words": 1234,
@@ -10,7 +10,6 @@
 			"u:type": "BOOK",
 			"x:items": [
 				{
-					"m:expanded": false,
 					"m:handle": "c2290a95-ca41-4181-89f2-18cb610ab716",
 					"m:order": 0,
 					"m:words": 1234,
@@ -18,7 +17,7 @@
 					"u:type": "PAGE"
 				},
 				{
-					"m:expanded": false,
+					"m:expanded": true,
 					"m:handle": "af3dc4a4-5f66-462d-b63b-9c4d7a7dec77",
 					"m:order": 1,
 					"m:words": 1234,
@@ -26,7 +25,6 @@
 					"u:type": "CHAPTER",
 					"x:items": [
 						{
-							"m:expanded": false,
 							"m:handle": "63913842-121f-43ed-8d9c-b3e2432599ab",
 							"m:order": 0,
 							"m:words": 1234,
@@ -34,7 +32,6 @@
 							"u:type": "SCENE"
 						},
 						{
-							"m:expanded": false,
 							"m:handle": "7e5a1a98-d1a3-44a1-ab4e-2b5d21d92201",
 							"m:order": 1,
 							"m:words": 1234,
@@ -44,7 +41,7 @@
 					]
 				},
 				{
-					"m:expanded": false,
+					"m:expanded": true,
 					"m:handle": "61fc6238-87cf-4b78-b2c7-a430776a2b7a",
 					"m:order": 2,
 					"m:words": 1234,
@@ -52,7 +49,6 @@
 					"u:type": "CHAPTER",
 					"x:items": [
 						{
-							"m:expanded": false,
 							"m:handle": "f3993444-4e43-4ace-bfdb-55ca659ca914",
 							"m:order": 0,
 							"m:words": 1234,
@@ -60,7 +56,6 @@
 							"u:type": "SCENE"
 						},
 						{
-							"m:expanded": false,
 							"m:handle": "ab6ba4f4-5658-4ff0-941d-2e0c687fe88d",
 							"m:order": 1,
 							"m:words": 1234,
@@ -70,7 +65,6 @@
 					]
 				},
 				{
-					"m:expanded": false,
 					"m:handle": "f1dffe99-3583-4f9c-9f0b-1a8f323b0670",
 					"m:order": 3,
 					"m:words": 1234,

--- a/src/gui/storytree.h
+++ b/src/gui/storytree.h
@@ -51,6 +51,7 @@ public:
     // Class Getters
 
     QModelIndex firstSelectedIndex();
+    void getAllChildren(const QModelIndex &index, QModelIndexList &children);
 
 public slots:
     void doEditName(bool checked);
@@ -58,6 +59,8 @@ public slots:
 private slots:
     void doOpenContextMenu(const QPoint &pos);
     void doAddChild(StoryItem *item, StoryItem::ItemType type, StoryModel::AddLocation loc);
+    void saveExpanded(const QModelIndex &index);
+    void saveCollapsed(const QModelIndex &index);
 
 private:
     StoryModel *m_model = nullptr;

--- a/src/project/storyitem.cpp
+++ b/src/project/storyitem.cpp
@@ -186,15 +186,35 @@ QJsonObject StoryItem::toJsonObject() {
     }
 
     QLatin1String type;
+    bool expandable = false;
     switch (m_type) {
-        case StoryItem::Root:      type = QLatin1String("ROOT"); break;
-        case StoryItem::Book:      type = QLatin1String("BOOK"); break;
-        case StoryItem::Partition: type = QLatin1String("PARTITION"); break;
-        case StoryItem::Chapter:   type = QLatin1String("CHAPTER"); break;
-        case StoryItem::Scene:     type = QLatin1String("SCENE"); break;
-        case StoryItem::Page:      type = QLatin1String("PAGE"); break;
+        case StoryItem::Root:
+            type = QLatin1String("ROOT");
+            expandable = false;
+            break;
+        case StoryItem::Book:
+            type = QLatin1String("BOOK");
+            expandable = true;
+            break;
+        case StoryItem::Partition:
+            type = QLatin1String("PARTITION");
+            expandable = true;
+            break;
+        case StoryItem::Chapter:
+            type = QLatin1String("CHAPTER");
+            expandable = true;
+            break;
+        case StoryItem::Scene:
+            type = QLatin1String("SCENE");
+            expandable = false;
+            break;
+        case StoryItem::Page:
+            type = QLatin1String("PAGE");
+            expandable = false;
+            break;
         case StoryItem::Invalid:
             return QJsonObject();
+            expandable = false;
             break;
     }
 
@@ -202,14 +222,16 @@ QJsonObject StoryItem::toJsonObject() {
         item[QLatin1String("u:type")]  = type;
         item[QLatin1String("x:items")] = children;
     } else {
-        item[QLatin1String("m:handle")]   = m_handle.toString(QUuid::WithoutBraces);
-        item[QLatin1String("m:order")]    = row();
-        item[QLatin1String("m:words")]    = m_words;
-        item[QLatin1String("m:expanded")] = m_expanded;
-        item[QLatin1String("u:name")]     = m_name;
-        item[QLatin1String("u:type")]     = type;
+        item[QLatin1String("m:handle")] = m_handle.toString(QUuid::WithoutBraces);
+        item[QLatin1String("m:order")]  = row();
+        item[QLatin1String("m:words")]  = m_words;
+        item[QLatin1String("u:name")]   = m_name;
+        item[QLatin1String("u:type")]   = type;
         if (children.size() > 0) {
             item[QLatin1String("x:items")] = children;
+        }
+        if (expandable) {
+            item[QLatin1String("m:expanded")] = m_expanded;
         }
     }
 

--- a/src/project/storyitem.cpp
+++ b/src/project/storyitem.cpp
@@ -44,10 +44,11 @@ StoryItem::StoryItem(const QUuid &uuid, const QString &name, ItemType type, Stor
     : m_parentItem(parent)
 {
     m_childItems = QVector<StoryItem*>{};
-    m_handle = uuid;
-    m_name   = name;
-    m_type   = type;
-    m_wCount = 0;
+    m_handle   = uuid;
+    m_name     = name;
+    m_type     = type;
+    m_words    = 0;
+    m_expanded = false;
 }
 
 StoryItem::~StoryItem() {
@@ -101,10 +102,11 @@ StoryItem *StoryItem::addChild(const QJsonObject &json) {
         return nullptr;
     }
 
-    QUuid    handle = QUuid();
-    QString  name   = "";
-    ItemType type   = StoryItem::Invalid;
-    int      wCount = 0;
+    QUuid    handle   = QUuid();
+    QString  name     = "";
+    ItemType type     = StoryItem::Invalid;
+    int      words    = 0;
+    bool     expanded = false;
 
     if (json.contains(QLatin1String("m:handle"))) {
         handle = QUuid(json[QLatin1String("m:handle")].toString());
@@ -116,7 +118,10 @@ StoryItem *StoryItem::addChild(const QJsonObject &json) {
         type = StoryItem::typeFromString(json[QLatin1String("u:type")].toString());
     }
     if (json.contains(QLatin1String("m:words"))) {
-        wCount = json[QLatin1String("m:words")].toInt();
+        words = json[QLatin1String("m:words")].toInt();
+    }
+    if (json.contains(QLatin1String("m:expanded"))) {
+        expanded = json[QLatin1String("m:expanded")].toBool();
     }
 
     if (type == StoryItem::Invalid) {
@@ -144,7 +149,8 @@ StoryItem *StoryItem::addChild(const QJsonObject &json) {
     }
     
     StoryItem *item = new StoryItem(handle, name, type, this);
-    item->setWordCount(wCount);
+    item->setWordCount(words);
+    item->setExpanded(expanded);
     m_childItems.append(item);
 
     if (json.contains(QLatin1String("x:items"))) {
@@ -196,11 +202,12 @@ QJsonObject StoryItem::toJsonObject() {
         item[QLatin1String("u:type")]  = type;
         item[QLatin1String("x:items")] = children;
     } else {
-        item[QLatin1String("m:handle")] = m_handle.toString(QUuid::WithoutBraces);
-        item[QLatin1String("m:order")]  = row();
-        item[QLatin1String("m:words")]  = m_wCount;
-        item[QLatin1String("u:name")]   = m_name;
-        item[QLatin1String("u:type")]   = type;
+        item[QLatin1String("m:handle")]   = m_handle.toString(QUuid::WithoutBraces);
+        item[QLatin1String("m:order")]    = row();
+        item[QLatin1String("m:words")]    = m_words;
+        item[QLatin1String("m:expanded")] = m_expanded;
+        item[QLatin1String("u:name")]     = m_name;
+        item[QLatin1String("u:type")]     = type;
         if (children.size() > 0) {
             item[QLatin1String("x:items")] = children;
         }
@@ -266,7 +273,11 @@ void StoryItem::setName(const QString &name) {
 
 
 void StoryItem::setWordCount(int count) {
-    m_wCount = count > 0 ? count : 0;
+    m_words = count > 0 ? count : 0;
+}
+
+void StoryItem::setExpanded(bool state) {
+    m_expanded = state;
 }
 
 /**
@@ -287,7 +298,7 @@ QString StoryItem::name() const {
 }
 
 int StoryItem::wordCount() const {
-    return m_wCount;
+    return m_words;
 }
 
 int StoryItem::childWordCounts() const {
@@ -296,6 +307,10 @@ int StoryItem::childWordCounts() const {
         tCount += child->childWordCounts();
     }
     return tCount;
+}
+
+bool StoryItem::isExpanded() const {
+    return m_expanded;
 }
 
 /**
@@ -372,7 +387,7 @@ int StoryItem::row() const {
 
 QVariant StoryItem::data() const {
     QVariantList itemData;
-    itemData << m_name << m_wCount << typeToString(m_type);
+    itemData << m_name << m_words << typeToString(m_type);
     return QVariant::fromValue(itemData);
 }
 

--- a/src/project/storyitem.h
+++ b/src/project/storyitem.h
@@ -52,6 +52,7 @@ public:
 
     void setName(const QString &name);
     void setWordCount(int count);
+    void setExpanded(bool state);
 
     // Class Getters
 
@@ -60,6 +61,7 @@ public:
     QString name() const;
     int wordCount() const;
     int childWordCounts() const;
+    bool isExpanded() const;
 
     // Static Methods
 
@@ -83,7 +85,8 @@ private:
     QUuid    m_handle;
     QString  m_name;
     ItemType m_type;
-    int      m_wCount;
+    int      m_words;
+    bool     m_expanded;
 
 };
 } // namespace Collett

--- a/src/project/storymodel.cpp
+++ b/src/project/storymodel.cpp
@@ -30,6 +30,7 @@
 #include <QJsonObject>
 #include <QModelIndex>
 #include <QLatin1String>
+#include <QModelIndexList>
 #include <QAbstractItemModel>
 
 namespace Collett {
@@ -201,6 +202,15 @@ QString StoryModel::itemName(const QModelIndex &index) {
     }
 }
 
+bool StoryModel::isExpanded(const QModelIndex &index) {
+    if (index.isValid()) {
+        StoryItem *item = static_cast<StoryItem*>(index.internalPointer());
+        return item->isExpanded();
+    } else {
+        return false;
+    }
+}
+
 /**
  * Model Edit
  * ==========
@@ -210,6 +220,13 @@ void StoryModel::setItemName(const QModelIndex &index, const QString &name) {
     if (index.isValid()) {
         StoryItem *item = static_cast<StoryItem*>(index.internalPointer());
         item->setName(name);
+    }
+}
+
+void StoryModel::setExpanded(const QModelIndex &index, bool state) {
+    if (index.isValid()) {
+        StoryItem *item = static_cast<StoryItem*>(index.internalPointer());
+        item->setExpanded(state);
     }
 }
 

--- a/src/project/storymodel.h
+++ b/src/project/storymodel.h
@@ -28,6 +28,7 @@
 #include <QString>
 #include <QJsonObject>
 #include <QModelIndex>
+#include <QModelIndexList>
 #include <QAbstractItemModel>
 
 namespace Collett {
@@ -55,10 +56,12 @@ public:
     StoryItem *storyItem(const QModelIndex &index);
     QUuid itemHandle(const QModelIndex &index);
     QString itemName(const QModelIndex &index);
+    bool isExpanded(const QModelIndex &index);
 
     // Model Edit
 
     void setItemName(const QModelIndex &index, const QString &name);
+    void setExpanded(const QModelIndex &index, bool state);
 
     // Model Access
 


### PR DESCRIPTION
**Summary:**

This PR adds the necessary code to save and restore the expanded/collapsed state of the story tree.

**Related Issue(s):**

Resolves #33

**Reviewer's Checklist:**

* [x] The header of all files contain a reference to the repository license
* [ ] The overall test coverage is increased or remains the same as before
* [ ] All tests are passing
* [ ] Function descriptions are complete and understandable
* [x] Only files that have been actively changed are committed
